### PR TITLE
better default database path

### DIFF
--- a/PyTMM/refractiveIndex.py
+++ b/PyTMM/refractiveIndex.py
@@ -32,8 +32,7 @@ from io import open
 class RefractiveIndex:
     """Class that parses the refractiveindex.info YAML database"""
 
-    def __init__(self, databasePath=os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                                                 os.path.normpath("../RefractiveIndex/"))):
+    def __init__(self, databasePath=os.path.join(os.path.expanduser("~"), "refractiveindex.info-database")):
         """
 
         :param databasePath:


### PR DESCRIPTION
currently, if you install via pip, the default database path for the refractivedindex.info database gets to be ~/.local/lib/python3.8/site-packages/RefractiveIndex/.
This is not a good default path (Only python libraries should be in site-packages).
This pull request changes it to ~/refractiveindex.info-database/.