### PR TITLE
implement automatic download of refractive index info database from Github

### DIFF
--- a/PyTMM/refractiveIndex.py
+++ b/PyTMM/refractiveIndex.py
@@ -33,13 +33,25 @@ class RefractiveIndex:
     """Class that parses the refractiveindex.info YAML database"""
 
     def __init__(self, databasePath=os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                                                 os.path.normpath("../RefractiveIndex/"))):
+                                                 os.path.normpath("../RefractiveIndex/")), auto_download=True):
         """
 
         :param databasePath:
         """
+
+        if not os.path.exists(databasePath) and auto_download:
+          import tempfile, urllib.request, zipfile, shutil
+          with tempfile.TemporaryDirectory() as tempdir:
+            zip_filename = os.path.join(tempdir, "db.zip")
+            print("downloading refractiveindex.info database...", file=sys.stderr)
+            urllib.request.urlretrieve('https://github.com/polyanskiy/refractiveindex.info-database/archive/refs/heads/master.zip', zip_filename)
+            print("extracting...", file=sys.stderr)
+            with zipfile.ZipFile(zip_filename, 'r') as zf: zf.extractall(tempdir)
+            shutil.move(os.path.join(tempdir, "refractiveindex.info-database-master", "database"), databasePath)
+            print("done", file=sys.stderr)
+
         self.referencePath = os.path.normpath(databasePath)
-        fileName = os.path.join(self.referencePath, os.path.normpath("library.yml"))
+        fileName = os.path.join(self.referencePath, "library.yml")
         with open(fileName, "rt", encoding="utf-8") as f:
             self.catalog = yaml.safe_load(f)
 


### PR DESCRIPTION
Implementation of an automatic download of the refractiveindex info database from the github master branch https://github.com/polyanskiy/refractiveindex.info-database/archive/refs/heads/master.zip.
(can be switched off with the keyword argument auto_download=False).

Together with #6, getting PyTMM running will be as easy as:

```
import PyTMM.refractiveIndex # pip3 install git+https://github.com/kitchenknif/PyTMM
catalog = PyTMM.refractiveIndex.RefractiveIndex()
mat = catalog.getMaterial('main', 'SiO2', 'Malitson')
n = mat.getRefractiveIndex(600)
```

(no previous download of the database needed)